### PR TITLE
rename ZNC to lowercase

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
-    "name": "ZNC",
-    "id": "ZNC",
+    "name": "znc",
+    "id": "znc",
     "packaging_format": 1,
     "description": {
         "en": "An advanced IRC Bouncer.",


### PR DESCRIPTION
To prevent this failure:

```
dpkg-gencontrol: error: illegal package name 'ZNC-ynh-deps': character 'Z' not allowed
```

Signed-off-by: RzR <rzr@users.sf.net>